### PR TITLE
Add project structure linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,9 +15,14 @@
 	},
 	"plugins": [
 		"@typescript-eslint",
-		"react-refresh"
+		"react-refresh",
+		"project-structure"
 	],
+	"settings": {
+        "project-structure/config-path": "project-structure.json"
+    },
 	"rules": {
+		"project-structure/file-structure": "error",
 		"indent": [
 			"warn",
 			"tab"

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@typescript-eslint/parser": "^7.1.1",
         "@vitejs/plugin-react": "^4.2.1",
         "eslint": "^8.57.0",
+        "eslint-plugin-project-structure": "^1.4.7",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
         "jsdom": "^24.0.0",
@@ -4081,6 +4082,141 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-project-structure": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-project-structure/-/eslint-plugin-project-structure-1.4.7.tgz",
+      "integrity": "sha512-VwcamMFxxE52D0qRQImwLfNEuXpN6OaOxlWNGNjigXRRMxz4/EHy/iw3k63bpfrBEli4CLfnvrbPt83NQE1wEg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.57.0",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/@typescript-eslint/types": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/@typescript-eslint/utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
@@ -8711,6 +8847,27 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint:structure": "eslint --parser ./node_modules/eslint-plugin-project-structure/dist/parser.js --rule project-structure/file-structure:error --ext .js,.jsx,.ts,.tsx,.html,.css,.svg,.png,.jpg,.json,.md .",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -31,6 +32,7 @@
     "@typescript-eslint/parser": "^7.1.1",
     "@vitejs/plugin-react": "^4.2.1",
     "eslint": "^8.57.0",
+    "eslint-plugin-project-structure": "^1.4.7",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
     "jsdom": "^24.0.0",

--- a/project-structure.json
+++ b/project-structure.json
@@ -1,0 +1,149 @@
+{
+	"structure": {
+        "children": [
+            {
+                "name": "public",
+                "children": []
+            },
+            {
+                "name": "src",
+                "children": [
+                    {
+                        "name": "main",
+                        "extension": ["tsx"]
+                    },
+					{
+						"name": "assets",
+						"children": []
+					},
+					{
+						"name": "vite-env.d",
+						"extension": ["ts"]
+					},
+					{
+						"name": "components",
+						"children": [
+                            {
+                                "name": "/^${{PascalCase}}$/",
+                                "children": [
+									{
+										"name": "/^${{ParentName}}$/",
+										"extension": ["tsx"]
+									},
+									{
+										"name": "/^${{ParentName}}(\\.(test|style|stories))?$/",
+										"extension": ["tsx", "ts"]
+									}
+								]
+                            }
+                        ]
+					},
+					{
+						"name": "routes",
+						"children": [
+                            {
+                                "name": "/^${{PascalCase}}$/",
+                                "children": [
+									{
+										"name": "/^${{ParentName}}$/",
+										"extension": ["tsx"]
+									},
+									{
+										"name": "/^${{ParentName}}(\\.(test|style|stories))?$/",
+										"extension": ["tsx", "ts"]
+									}
+								]
+                            }
+                        ]
+					}
+                ]
+            },
+			{
+				"name": "templates",
+				"children": [
+					{
+						"name": "TemplateName",
+						"extension": ["tsx"]
+					},
+					{
+						"name": "TemplateName.style",
+						"extension": ["ts", "tsx"]
+					},
+					{
+						"name": "TemplateName.test",
+						"extension": ["tsx"]
+					},
+					{
+						"name": "TemplateName.stories",
+						"extension": ["ts", "tsx"]
+					}
+				]
+			},
+			{
+				"name": "test-mocks",
+				"children": []
+			},
+			{
+				"name": ".eslintrc",
+				"extension": ["json"]
+			},
+			{
+				"name": ".babelrc"
+			},
+			{
+				"name": ".gitignore"
+			},
+			{
+				"name": "generate-react-cli",
+				"extension": ["json"]
+			},
+			{
+				"name": "index",
+				"extension": ["html"]
+			},
+			{
+				"name": "jest.config",
+				"extension": ["js", "ts"]
+			},
+			{
+				"name": "jest.setup",
+				"extension": ["js", "ts"]
+			},
+			{
+				"name": "LICENSE"
+			},
+			{
+				"name": "package",
+				"extension": ["json"]
+			},
+			{
+				"name": "package-lock",
+				"extension": ["json"]
+			},
+			{
+				"name": "project-structure",
+				"extension": ["json"]
+			},
+			{
+				"name": "README",
+				"extension": ["md"]
+			},
+			{
+				"name": "tsconfig",
+				"extension": ["json"]
+			},
+			{
+				"name": "tsconfig.node",
+				"extension": ["json"]
+			},
+			{
+				"name": "vite",
+				"extension": ["config.ts"]
+			},
+			{
+				"name": "vite.config",
+				"extension": ["ts"]
+			}
+        ]
+    }
+}


### PR DESCRIPTION
Adds project structure check using [eslint-plugin-project-structure](https://github.com/Igorkowalski94/eslint-plugin-project-structure) to ensure that additions to the codebase follow the directory structure and naming conventions specified in `project-structure.json`.

The check can be run from the command line using `npm run lint:structure`, with the intention that this will be set up as a CI step that must pass before a pull request can be merged.

This commit is synced from the template repository, ensuring all projects have the same config going forward.